### PR TITLE
check for resp != nil to fix panic

### DIFF
--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -121,7 +121,7 @@ func listAdministratorRoleFlags(
 	resp, err := rq.Do(ctx, req, &adminFlags)
 	if err != nil {
 		// If we don't have access to the role endpoint, we should just return nil
-		if resp.StatusCode == http.StatusForbidden {
+		if resp != nil && resp.StatusCode == http.StatusForbidden {
 			return nil, nil, errMissingRolePermissions
 		}
 


### PR DESCRIPTION
https://us3.datadoghq.com/logs?query=%28panic%20-%22handle-issue-updated%3A%22%20OR%20%40panic%3A%40%29%20service%3Abe-temporal-sync&agg_m=count&agg_m_source=base&agg_q=env%2Ccluster_name%2Cpod_name&agg_q_source=base%2Cbase%2Cbase&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZtpxtomxn4pgAAAABhBWnRweHVhcUFBQ2ZMcHFZMFVYU0ZnQ0kAAAAkZjE5YjY5YzYtZjY4MS00OTg4LWE1MzctNjBkMTE5MTYyZjZlAAAo_Q&fromUser=true&messageDisplay=inline&refresh_mode=sliding&sort_m=%2C%2C&sort_m_source=%2C%2C&sort_t=%2C%2C&storage=hot&stream_sort=desc&top_n=10%2C10%2C10&top_o=top%2Ctop%2Ctop&viz=timeseries&x_missing=true%2Ctrue%2Ctrue&from_ts=1767005930000&to_ts=1767006230000&live=false

HAppned right after deploy (seems like a network failue could have triggered the resp == nil response and that was not handled in code 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a potential crash in role administration when access is denied due to insufficient permissions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->