### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-okta-ciam/main.go
+++ b/cmd/baton-okta-ciam/main.go
@@ -65,6 +65,7 @@ func getConnector(ctx context.Context, oc *config.OktaCiam) (types.ConnectorServ
 		Domain:              oc.Domain,
 		ApiToken:            oc.ApiToken,
 		CiamEmailDomains:    oc.CiamEmailDomains,
+		BaseURL:             oc.BaseUrl,
 		Cache:               oc.Cache,
 		CacheTTI:            cacheTTI,
 		CacheTTL:            cacheTTL,

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -7,13 +7,14 @@ type OktaCiam struct {
 	Domain string `mapstructure:"domain"`
 	ApiToken string `mapstructure:"api-token"`
 	CiamEmailDomains []string `mapstructure:"ciam-email-domains"`
+	BaseUrl string `mapstructure:"base-url"`
 	Cache bool `mapstructure:"cache"`
 	CacheTti int `mapstructure:"cache-tti"`
 	CacheTtl int `mapstructure:"cache-ttl"`
 	SkipSecondaryEmails bool `mapstructure:"skip-secondary-emails"`
 }
 
-func (c* OktaCiam) findFieldByTag(tagValue string) (any, bool) {
+func (c *OktaCiam) findFieldByTag(tagValue string) (any, bool) {
 	v := reflect.ValueOf(c).Elem() // Dereference pointer to struct
 	t := v.Type()
 
@@ -45,11 +46,13 @@ func (c *OktaCiam) GetString(fieldName string) string {
 	if !ok {
 		return ""
 	}
-	t, ok := v.(string)
-	if !ok {
-		panic("wrong type")
+	if t, ok := v.(string); ok {
+		return t
 	}
-	return t
+	if t, ok := v.([]byte); ok {
+		return string(t)
+	}
+	panic("wrong type")
 }
 
 func (c *OktaCiam) GetInt(fieldName string) int {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,6 +27,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the Okta CIAM API URL (for testing)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 
 	cache               = field.BoolField("cache", field.WithDescription("Enable response cache"), field.WithDefaultValue(true))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ var (
 	baseURL = field.StringField(
 		"base-url",
 		field.WithDescription("Override the Okta CIAM API URL (for testing)"),
+		field.WithHidden(true),
 	)
 
 	cache               = field.BoolField("cache", field.WithDescription("Enable response cache"), field.WithDefaultValue(true))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,10 @@ var (
 		field.WithDisplayName("Okta email domains (optional)"),
 		field.WithDescription("The email domains to use for CIAM mode. Any users that don't have an email address with one of the provided domains will be ignored, unless explicitly granted a role"),
 	)
+	baseURL = field.StringField(
+		"base-url",
+		field.WithDescription("Override the Okta CIAM API URL (for testing)"),
+	)
 
 	cache               = field.BoolField("cache", field.WithDescription("Enable response cache"), field.WithDefaultValue(true))
 	cacheTTI            = field.IntField("cache-tti", field.WithDescription("Response cache cleanup interval in seconds"), field.WithDefaultValue(60))
@@ -37,6 +41,7 @@ var Config = field.NewConfiguration([]field.SchemaField{
 	domain,
 	apiToken,
 	ciamEmailDomains,
+	baseURL,
 	cache,
 	cacheTTI,
 	cacheTTL,

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -29,6 +29,7 @@ type Config struct {
 	Domain           string
 	ApiToken         string
 	CiamEmailDomains []string
+	BaseURL          string
 
 	Cache               bool
 	CacheTTI            int32
@@ -198,9 +199,15 @@ func New(ctx context.Context, cfg *Config) (*Okta, error) {
 		return nil, err
 	}
 
+	// Use base URL if provided, otherwise construct from domain
+	orgURL := cfg.BaseURL
+	if orgURL == "" {
+		orgURL = fmt.Sprintf("https://%s", cfg.Domain)
+	}
+
 	if cfg.ApiToken != "" && cfg.Domain != "" {
 		_, oktaClient, err = okta.NewClient(ctx,
-			okta.WithOrgUrl(fmt.Sprintf("https://%s", cfg.Domain)),
+			okta.WithOrgUrl(orgURL),
 			okta.WithToken(cfg.ApiToken),
 			okta.WithHttpClientPtr(client),
 			okta.WithCache(cfg.Cache),


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-okta-ciam/main.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/connector.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-okta-ciam --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.